### PR TITLE
Makes advanced configuration work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+advanced/media
+advanced/data

--- a/advanced/Dockerfile
+++ b/advanced/Dockerfile
@@ -2,17 +2,18 @@ FROM benhutchins/taiga
 MAINTAINER Benjamin Hutchins <ben@hutchins.co>
 
 # Install additional extensions
-RUN pip install --no-cache-dir \
-      taiga-contrib-slack \
-      taiga-contrib-ldap-auth \
-      taiga-contrib-gogs
+RUN LC_ALL=C pip install --no-cache-dir \
+      taiga-contrib-gogs \
+      taiga-contrib-slack  
 
-ADD https://github.com/taigaio/taiga-contrib-slack/raw/master/front/dist/slack.js /usr/src/taiga-front-dist/dist/slack.js
-ADD https://raw.githubusercontent.com/taigaio/taiga-contrib-gogs/master/front/dist/gogs.js /usr/src/taiga-fromt-dist/dist/gogs.js
-ADD https://raw.githubusercontent.com/taigaio/taiga-contrib-gogs/master/front/dist/gogs.json /usr/src/taiga-fromt-dist/dist/gogs.json
+RUN mkdir -p /usr/src/taiga-front-dist/dist/plugins/slack
+RUN mkdir -p /usr/src/taiga-front-dist/dist/plugins/gogs
+
+ADD https://github.com/taigaio/taiga-contrib-slack/raw/master/front/dist/slack.json /usr/src/taiga-front-dist/dist/plugins/slack/slack.json
+ADD https://github.com/taigaio/taiga-contrib-slack/raw/master/front/dist/slack.js /usr/src/taiga-front-dist/dist/plugins/slack/slack.js
+ADD https://raw.githubusercontent.com/taigaio/taiga-contrib-gogs/master/front/dist/gogs.js /usr/src/taiga-front-dist/dist/plugins/gogs/gogs.js
+ADD https://raw.githubusercontent.com/taigaio/taiga-contrib-gogs/master/front/dist/gogs.json /usr/src/taiga-front-dist/dist/plugins/gogs/gogs.json
 
 COPY taiga-conf/local.py /taiga/local.py
 COPY taiga-conf/conf.json /taiga/conf.json
-
-RUN python manage.py migrate taiga_contrib_gogs
 

--- a/advanced/Dockerfile
+++ b/advanced/Dockerfile
@@ -4,9 +4,15 @@ MAINTAINER Benjamin Hutchins <ben@hutchins.co>
 # Install additional extensions
 RUN pip install --no-cache-dir \
       taiga-contrib-slack \
-      taiga-contrib-ldap-auth
+      taiga-contrib-ldap-auth \
+      taiga-contrib-gogs
 
 ADD https://github.com/taigaio/taiga-contrib-slack/raw/master/front/dist/slack.js /usr/src/taiga-front-dist/dist/slack.js
+ADD https://raw.githubusercontent.com/taigaio/taiga-contrib-gogs/master/front/dist/gogs.js /usr/src/taiga-fromt-dist/dist/gogs.js
+ADD https://raw.githubusercontent.com/taigaio/taiga-contrib-gogs/master/front/dist/gogs.json /usr/src/taiga-fromt-dist/dist/gogs.json
 
 COPY taiga-conf/local.py /taiga/local.py
 COPY taiga-conf/conf.json /taiga/conf.json
+
+RUN python manage.py migrate taiga_contrib_gogs
+

--- a/advanced/docker-compose.yml
+++ b/advanced/docker-compose.yml
@@ -1,11 +1,15 @@
 postgres:
   image: postgres
   environment:
-    POSTGRES_PASSWORD: password
+    POSTGRES_PASSWORD: password 
+  volumes:
+    # This ensures files uploaded to Taiga are not lost when recreating
+    # your taiga container during upgrades
+    - ./data:/var/lib/postgresql/data
 
 rabbit:
   image: rabbitmq:3
-  hostname: taiga-rabbit
+  hostname: rabbit
 
 redis:
   image: redis:3
@@ -31,12 +35,12 @@ taiga:
     - rabbit
     - redis
   environment:
-    TAIGA_HOSTNAME: taiga.mycompany.com
+    TAIGA_HOSTNAME: example.com
     # TAIGA_SSL: 'true' # To enable SSL, uncomment this line
 
-    TAIGA_DB_HOST: postgres
-    TAIGA_DB_NAME: taiga
-    TAIGA_DB_USER: taiga
+    #TAIGA_DB_HOST: postgres
+    #TAIGA_DB_NAME: taiga
+    #TAIGA_DB_USER: taiga
     TAIGA_DB_PASSWORD: password
   volumes:
     # This ensures files uploaded to Taiga are not lost when recreating

--- a/advanced/taiga-conf/conf.json
+++ b/advanced/taiga-conf/conf.json
@@ -12,6 +12,9 @@
     "privacyPolicyUrl": null,
     "termsOfServiceUrl": null,
     "maxUploadFileSize": null,
-    "contribPlugins": ["/slack.js"],
+    "contribPlugins": [
+	"/slack.js"
+        "/gogs.json"
+    ],
     "loginFormType": "ldap"
 }

--- a/advanced/taiga-conf/conf.json
+++ b/advanced/taiga-conf/conf.json
@@ -1,5 +1,5 @@
 {
-    "api": "http://TAIGA_HOSTNAME/api/v1/",
+    "api": "http://taiga.goodworkapps.com/api/v1/",
     "eventsUrl": null,
     "eventsMaxMissedHeartbeats": 5,
     "eventsHeartbeatIntervalTime": 60000,
@@ -13,8 +13,8 @@
     "termsOfServiceUrl": null,
     "maxUploadFileSize": null,
     "contribPlugins": [
-	"/slack.js"
-        "/gogs.json"
+	"/plugins/slack/slack.json",
+	"/plugins/gogs/gogs.json"
     ],
     "loginFormType": "ldap"
 }

--- a/advanced/taiga-conf/local.py
+++ b/advanced/taiga-conf/local.py
@@ -23,3 +23,14 @@ INSTALLED_APPS += ["taiga_contrib_slack"]
 INSTALLED_APPS += ["taiga_contrib_gogs"]
 PROJECT_MODULES_CONFIGURATORS["gogs"] = "taiga_contrib_gogs.services.get_or_generate_config"
 
+DEFAULT_FROM_EMAIL = "your@email.com"
+SERVER_EMAIL = DEFAULT_FROM_EMAIL
+
+# Uncomment and populate with proper connection parameters
+# for enable email sending. EMAIL_HOST_USER should end by @domain.tld
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_USE_TLS = True
+EMAIL_HOST = "smtp.mail.com"
+EMAIL_HOST_USER = "your@email.com"
+EMAIL_HOST_PASSWORD = "password"
+EMAIL_PORT = 587

--- a/advanced/taiga-conf/local.py
+++ b/advanced/taiga-conf/local.py
@@ -17,3 +17,9 @@ INSTALLED_APPS += ["taiga_contrib_slack"]
 ## LDAP
 # see https://github.com/ensky/taiga-contrib-ldap-auth
 # INSTALLED_APPS += ["taiga_contrib_ldap_auth"]
+
+## GOGS
+# see https://github.com/taigaio/taiga-contrib-gogs
+INSTALLED_APPS += ["taiga_contrib_gogs"]
+PROJECT_MODULES_CONFIGURATORS["gogs"] = "taiga_contrib_gogs.services.get_or_generate_config"
+


### PR DESCRIPTION
Fixes couple of problems in `advanced` configuration:
- slack plugin was installed only partially there, no `slack.json` file and that made this config not working
- moves postgres data out of container for easy migrations afterwards

Also this adds gogs (http://gogs.io) integration plugin
